### PR TITLE
面接日程の表示・登録・編集・削除

### DIFF
--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,10 @@
+class InterviewsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,23 +1,30 @@
 class InterviewsController < ApplicationController
   def index
-    @interviews = current_user.interviews
+    @user = set_user
+    @interviews = @user.interviews
   end
 
   def new
+    @user = set_user
     @interview = Interview.new
   end
 
   def create
-    @interview = current_user.interviews.build(interview_params)
+    @user = set_user
+    @interview = @user.interviews.build(interview_params)
     if @interview.save
       flash[:notice] = 'Suscessfully created.'
     else
       flash[:alert] = 'Failed to create a interview.'
     end
-    redirect_to interviews_path
+    redirect_to user_interviews_path
   end
 
   private
+
+    def set_user
+      user = User.find_by(id: params[:user_id])
+    end
 
     def interview_params
       params.require(:interview).permit(:scheduled_at)

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -14,6 +14,7 @@ class InterviewsController < ApplicationController
 
   def create
     @interview = @user.interviews.build(interview_params)
+    @interview.is_available = 'to_be_determined'
     if @interview.save
       flash[:notice] = 'Suscessfully created.'
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -4,7 +4,7 @@ class InterviewsController < ApplicationController
   before_action :set_interview, only: [:edit, :update, :destroy]
 
   def index
-    @interviews = @user.interviews
+    @interviews = @user.interviews.order(:scheduled_at)
   end
 
   def new

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -9,6 +9,7 @@ class InterviewsController < ApplicationController
 
   def new
     @interview = Interview.new
+    @path = user_interviews_path(@user.id)
   end
 
   def create
@@ -22,10 +23,11 @@ class InterviewsController < ApplicationController
   end
 
   def edit
+    @path = user_interview_path(@user.id, @interview.id)
   end
 
   def update
-    if @interview.update(params[:scheduled_at])
+    if @interview.update(interview_params)
       flash[:notice] = 'Successfully updated.'
     else
       flash[:alert] = 'Failed to update the interview candidate date.'

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,16 +1,15 @@
 class InterviewsController < ApplicationController
+  before_action :set_user
+
   def index
-    @user = set_user
     @interviews = @user.interviews
   end
 
   def new
-    @user = set_user
     @interview = Interview.new
   end
 
   def create
-    @user = set_user
     @interview = @user.interviews.build(interview_params)
     if @interview.save
       flash[:notice] = 'Suscessfully created.'
@@ -23,7 +22,7 @@ class InterviewsController < ApplicationController
   private
 
     def set_user
-      user = User.find_by(id: params[:user_id])
+      @user = User.find_by(id: params[:user_id])
     end
 
     def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -14,7 +14,7 @@ class InterviewsController < ApplicationController
 
   def create
     @interview = @user.interviews.build(interview_params)
-    @interview.is_available = 'to_be_determined'
+    @interview.is_available = 'pending'
     if @interview.save
       flash[:notice] = 'Suscessfully created.'
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -4,6 +4,7 @@ class InterviewsController < ApplicationController
   end
 
   def new
+    @interview = Interview.new
   end
 
   def create

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -20,6 +20,15 @@ class InterviewsController < ApplicationController
     redirect_to user_interviews_path
   end
 
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
   private
 
     def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,6 @@
 class InterviewsController < ApplicationController
   def index
+    @interviews = current_user.interviews
   end
 
   def new

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -56,7 +56,7 @@ class InterviewsController < ApplicationController
 
     def correct_user
       return if @user == current_user
-      flash[:alert] = 'Only your own profile can be edited.'
+      flash[:alert] = 'Only your own interviews can be accessed.'
       redirect_to authenticated_root_path
     end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -14,7 +14,7 @@ class InterviewsController < ApplicationController
 
   def create
     @interview = @user.interviews.build(interview_params)
-    @interview.is_available = 'pending'
+    @interview.availability = 'pending'
     if @interview.save
       flash[:notice] = 'Suscessfully created.'
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -16,7 +16,7 @@ class InterviewsController < ApplicationController
     if @interview.save
       flash[:notice] = 'Suscessfully created.'
     else
-      flash[:alert] = 'Failed to create a interview.'
+      flash[:alert] = 'Failed to create a interview candidate date and time.'
     end
     redirect_to user_interviews_path
   end
@@ -25,9 +25,21 @@ class InterviewsController < ApplicationController
   end
 
   def update
+    if @interview.update(params[:scheduled_at])
+      flash[:notice] = 'Successfully updated.'
+    else
+      flash[:alert] = 'Failed to update the interview candidate date.'
+    end
+    redirect_to user_interviews_path(@user.id)
   end
 
   def destroy
+    if @interview.destroy
+      flash[:notice] = 'Successfully destroyed.'
+    else
+      flash[:alert] = 'Failed to destroy the interview candidate date.'
+    end
+    redirect_to user_interviews_path(@user.id)
   end
 
   private

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,6 @@
 class InterviewsController < ApplicationController
-  before_action :set_user
+  before_action :authenticate_user!
+  before_action :set_user, :correct_user
 
   def index
     @interviews = @user.interviews
@@ -21,11 +22,17 @@ class InterviewsController < ApplicationController
 
   private
 
-    def set_user
-      @user = User.find_by(id: params[:user_id])
-    end
-
     def interview_params
       params.require(:interview).permit(:scheduled_at)
+    end
+
+    def set_user
+      @user = User.find(params[:user_id])
+    end
+
+    def correct_user
+      return if @user == current_user
+      flash[:alert] = 'Only your own profile can be edited.'
+      redirect_to authenticated_root_path
     end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,7 @@
 class InterviewsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_user, :correct_user
+  before_action :set_interview, only: [:edit, :update, :destroy]
 
   def index
     @interviews = @user.interviews
@@ -43,5 +44,9 @@ class InterviewsController < ApplicationController
       return if @user == current_user
       flash[:alert] = 'Only your own profile can be edited.'
       redirect_to authenticated_root_path
+    end
+
+    def set_interview
+      @interview = @user.interviews.find(params[:id])
     end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -8,5 +8,18 @@ class InterviewsController < ApplicationController
   end
 
   def create
+    @interview = current_user.interviews.build(interview_params)
+    if @interview.save
+      flash[:notice] = 'Suscessfully created.'
+    else
+      flash[:alert] = 'Failed to create a interview.'
+    end
+    redirect_to interviews_path
   end
+
+  private
+
+    def interview_params
+      params.require(:interview).permit(:scheduled_at)
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  before_action :correct_user, only: [:edit, :update]
+  before_action :set_user, :correct_user, only: [:edit, :update]
 
   def index
     @users = User.where.not(id: current_user.id)
@@ -22,11 +22,13 @@ class UsersController < ApplicationController
       params.require(:user).permit(:name, :date_of_birth, :gender, :school)
     end
 
-    def correct_user
+    def set_user
       @user = User.find(params[:id])
-      unless @user == current_user
-        flash[:alert] = 'Only your own profile can be edited.'
-        redirect_to authenticated_root_path
-      end
+    end
+
+    def correct_user
+      return if @user == current_user
+      flash[:alert] = 'Only your own profile can be edited.'
+      redirect_to authenticated_root_path
     end
 end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,2 @@
+class Interview < ApplicationRecord
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,2 +1,3 @@
 class Interview < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,5 +1,5 @@
 class Interview < ApplicationRecord
-  enum is_available: { to_be_determined: 0, approval: 1, disapproval: 2 }
+  enum is_available: { pending: 0, approval: 1, disapproval: 2 }
   validates :scheduled_at, presence: true
   validates :is_available, presence: true
   belongs_to :user

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,6 @@
 class Interview < ApplicationRecord
+  enum is_available: { to_be_determined: 0, approval: 1, disapproval: 2 }
   validates :scheduled_at, presence: true
+  validates :is_available, presence: true
   belongs_to :user
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,4 @@
 class Interview < ApplicationRecord
   belongs_to :user
+  validates :scheduled_at, presence: true
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,6 +1,6 @@
 class Interview < ApplicationRecord
-  enum is_available: { pending: 0, approval: 1, disapproval: 2 }
+  enum availability: { pending: 0, approval: 1, disapproval: 2 }
   validates :scheduled_at, presence: true
-  validates :is_available, presence: true
+  validates :availability, presence: true
   belongs_to :user
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,4 @@
 class Interview < ApplicationRecord
-  belongs_to :user
   validates :scheduled_at, presence: true
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   enum gender: [:male, :female, :other]
   before_validation :calc_age
   validates :age, numericality: { greater_than_or_equal_to: 0 }
+  has_many :interviews
 
   private
     def calc_age

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  enum gender: [:male, :female, :other]
+  enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9 }
   before_validation :calc_age
   validates :age, numericality: { greater_than_or_equal_to: 0 }
   has_many :interviews

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   enum gender: { not_known: 0, male: 1, female: 2, not_applicable: 9 }
   before_validation :calc_age
   validates :age, numericality: { greater_than_or_equal_to: 0 }
-  has_many :interviews
+  has_many :interviews, dependent: :delete_all
 
   private
     def calc_age

--- a/app/views/interviews/_interview_form.html.erb
+++ b/app/views/interviews/_interview_form.html.erb
@@ -1,0 +1,5 @@
+<%= form_for interview, url: user_interviews_path(user.id) do |f| %>
+  <%= f.label '面接日程' %><br>
+  <%= f.datetime_field :scheduled_at %><br>
+  <%= f.submit button_name %><br>
+<% end %>

--- a/app/views/interviews/_interview_form.html.erb
+++ b/app/views/interviews/_interview_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for interview, url: user_interviews_path(user.id) do |f| %>
+<%= form_for interview, url: path do |f| %>
   <%= f.label '面接日程' %><br>
   <%= f.datetime_field :scheduled_at %><br>
   <%= f.submit button_name %><br>

--- a/app/views/interviews/create.html.erb
+++ b/app/views/interviews/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#create</h1>
+<p>Find me in app/views/interviews/create.html.erb</p>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Interviews#edit</h1>
+
+<%= render 'interview_form', {user: @user, interview: @interview, button_name: '更新'} %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Interviews#edit</h1>
 
-<%= render 'interview_form', {user: @user, interview: @interview, button_name: '更新'} %>
+<%= render 'interview_form', {user: @user, interview: @interview, path: @path, button_name: '更新'} %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#index</h1>
+<p>Find me in app/views/interviews/index.html.erb</p>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -4,7 +4,7 @@
   <% if @interviews.any? %>
     <% @interviews.each do |interview| %>
       <li>
-        <%= interview.scheduled_on %>
+        <%= interview.scheduled_at %>
         <%= interview.is_available %>
       </li>
     <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,2 +1,14 @@
 <h1>Interviews#index</h1>
-<p>Find me in app/views/interviews/index.html.erb</p>
+
+<ul class="interviews">
+  <% if @interviews.any? %>
+    <% @interviews.each do |interview| %>
+      <li>
+        <%= interview.scheduled_on %>
+        <%= interview.is_available %>
+      </li>
+    <% end %>
+  <% else %>
+    面接日程がありません。
+  <% end %>
+</ul>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -4,7 +4,7 @@
   <% if @interviews.any? %>
     <% @interviews.each do |interview| %>
       <li>
-        <%= interview.scheduled_at %>
+        <%= interview.scheduled_at.strftime('%Y年%m月%d日 %H:%M:%S') %>
         <%= interview.is_available %>
       </li>
     <% end %>
@@ -13,4 +13,4 @@
   <% end %>
 </ul>
 
-<%= link_to '面接日程作成', new_interview_path %>
+<%= link_to '面接日程作成', new_user_interview_path(current_user.id) %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -13,4 +13,4 @@
   <% end %>
 </ul>
 
-<%= link_to '面接日程作成', new_user_interview_path(current_user.id) %>
+<%= link_to '面接日程作成', new_user_interview_path(@user.id) %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -12,3 +12,5 @@
     面接日程がありません。
   <% end %>
 </ul>
+
+<%= link_to '面接日程作成', new_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -5,7 +5,7 @@
     <% @interviews.each do |interview| %>
       <li>
         <%= interview.scheduled_at.strftime('%Y年%m月%d日 %H:%M:%S') %>
-        <%= interview.is_available %>
+        <%= interview.availability %>
         <%= link_to '編集', edit_user_interview_path(@user.id, interview.id) %>
         <%= link_to '削除', user_interview_path(@user.id, interview.id), method: :delete %>
       </li>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -6,6 +6,8 @@
       <li>
         <%= interview.scheduled_at.strftime('%Y年%m月%d日 %H:%M:%S') %>
         <%= interview.is_available %>
+        <%= link_to '編集', edit_user_interview_path(@user.id, interview.id) %>
+        <%= link_to '削除', user_interview_path(@user.id, interview.id), method: :delete %>
       </li>
     <% end %>
   <% else %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#new</h1>
+<p>Find me in app/views/interviews/new.html.erb</p>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,2 +1,7 @@
 <h1>Interviews#new</h1>
-<p>Find me in app/views/interviews/new.html.erb</p>
+
+<%= form_for(@interview) do |f| %>
+  <%= f.label '面接日程' %><br>
+  <%= f.datetime_field :scheduled_at %><br>
+ <%= f.submit "作成" %><br>
+<% end %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,7 +1,3 @@
 <h1>Interviews#new</h1>
 
-<%= form_for @interview, url: user_interviews_path(@user.id) do |f| %>
-  <%= f.label '面接日程' %><br>
-  <%= f.datetime_field :scheduled_at %><br>
-  <%= f.submit "作成" %><br>
-<% end %>
+<%= render 'interview_form', {user: @user, interview: @interview, button_name: '作成'} %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,7 +1,7 @@
 <h1>Interviews#new</h1>
 
-<%= form_for(@interview) do |f| %>
+<%= form_for @interview, url: user_interviews_path(@user.id) do |f| %>
   <%= f.label '面接日程' %><br>
   <%= f.datetime_field :scheduled_at %><br>
- <%= f.submit "作成" %><br>
+  <%= f.submit "作成" %><br>
 <% end %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,3 +1,3 @@
 <h1>Interviews#new</h1>
 
-<%= render 'interview_form', {user: @user, interview: @interview, button_name: '作成'} %>
+<%= render 'interview_form', {user: @user, interview: @interview, path: @path, button_name: '作成'} %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,7 @@
 <header>
   <% if user_signed_in? %>
     <%= link_to "[プロフィール]", edit_user_path(current_user.id) %>
-    <%= link_to "[自分の面接一覧]", interviews_path %>
+    <%= link_to "[自分の面接一覧]", user_interviews_path(current_user.id) %>
     <%= link_to "[ログアウト]", destroy_user_session_path, method: :delete %>
   <% end %>
 </header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,8 @@
 <header>
   <% if user_signed_in? %>
-    <%= link_to "[プロフィール]", edit_user_path(current_user.id) %>
-    <%= link_to "[自分の面接一覧]", user_interviews_path(current_user.id) %>
-    <%= link_to "[ログアウト]", destroy_user_session_path, method: :delete %>
+    <%= link_to '[他のユーザー一覧]', users_path %>
+    <%= link_to '[プロフィール]', edit_user_path(current_user.id) %>
+    <%= link_to '[自分の面接一覧]', user_interviews_path(current_user.id) %>
+    <%= link_to '[ログアウト]', destroy_user_session_path, method: :delete %>
   <% end %>
 </header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,7 @@
 <header>
   <% if user_signed_in? %>
     <%= link_to "[プロフィール]", edit_user_path(current_user.id) %>
+    <%= link_to "[自分の面接一覧]", interviews_path %>
     <%= link_to "[ログアウト]", destroy_user_session_path, method: :delete %>
   <% end %>
 </header>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,7 +6,7 @@
   <%= f.label '生年月日' %><br>
   <%= f.date_field :date_of_birth %><br>
   <%= f.label '性別' %><br>
-  <%= f.select :gender, User.genders.keys.to_a, {} %><br>
+  <%= f.select :gender, {'' => :not_known, '男性' => :male, '女性' => :female, 'その他'=> :not_applicable} %><br>
   <%= f.label '学校' %><br>
   <%= f.text_field :school %><br>
   <%= f.submit "プロフィールを更新" %><br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,7 @@ module ENavigator
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update] do
-    resources :interviews, only: [:index, :new, :create]
+    resources :interviews, only: [:index, :new, :create, :edit, :update, :destroy]
   end
   devise_for :users
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,10 @@ Rails.application.routes.draw do
   devise_for :users
   devise_scope :user do
     authenticated :user do
-      root 'users#index', as: :authenticated_root
+      root to: redirect('/users/'), as: :authenticated_root
     end
     unauthenticated do
-      root 'devise/sessions#new', as: :unauthenticated_root
+      root to: redirect('/users/sign_in'), as: :unauthenticated_root
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  get 'interviews/index'
+
+  get 'interviews/new'
+
+  get 'interviews/create'
+
   resources :users, only: [:index, :edit, :update]
   devise_for :users
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  resources :interviews, only: [:index, :new, :create]
-  resources :users, only: [:index, :edit, :update]
+  resources :users, only: [:index, :edit, :update] do
+    resources :interviews, only: [:index, :new, :create]
+  end
   devise_for :users
   devise_scope :user do
     authenticated :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,5 @@
 Rails.application.routes.draw do
-  get 'interviews/index'
-
-  get 'interviews/new'
-
-  get 'interviews/create'
-
+  resources :interviews, only: [:index, :new, :create]
   resources :users, only: [:index, :edit, :update]
   devise_for :users
   devise_scope :user do

--- a/db/migrate/20180408113537_create_interviews.rb
+++ b/db/migrate/20180408113537_create_interviews.rb
@@ -1,0 +1,10 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.datetime :scheduled_at
+      t.boolean :is_available
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180408123033_add_user_reference_to_interviews.rb
+++ b/db/migrate/20180408123033_add_user_reference_to_interviews.rb
@@ -1,0 +1,5 @@
+class AddUserReferenceToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :interviews, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20180420110004_remove_is_available_from_interviews.rb
+++ b/db/migrate/20180420110004_remove_is_available_from_interviews.rb
@@ -1,0 +1,5 @@
+class RemoveIsAvailableFromInterviews < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :interviews, :is_available, :boolean
+  end
+end

--- a/db/migrate/20180420110313_add_is_available_to_interviews.rb
+++ b/db/migrate/20180420110313_add_is_available_to_interviews.rb
@@ -1,0 +1,5 @@
+class AddIsAvailableToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    add_column :interviews, :is_available, :integer
+  end
+end

--- a/db/migrate/20180423121032_rename_is_available_of_interviews.rb
+++ b/db/migrate/20180423121032_rename_is_available_of_interviews.rb
@@ -1,0 +1,5 @@
+class RenameIsAvailableOfInterviews < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :interviews, :is_available, :availability
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180420110313) do
+ActiveRecord::Schema.define(version: 20180423121032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20180420110313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
-    t.integer "is_available"
+    t.integer "availability"
     t.index ["user_id"], name: "index_interviews_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180328135509) do
+ActiveRecord::Schema.define(version: 20180408113537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "scheduled_at"
+    t.boolean "is_available"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180408113537) do
+ActiveRecord::Schema.define(version: 20180408123033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20180408113537) do
     t.boolean "is_available"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_interviews_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -44,4 +46,5 @@ ActiveRecord::Schema.define(version: 20180408113537) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "interviews", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180420110004) do
+ActiveRecord::Schema.define(version: 20180420110313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20180420110004) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "is_available"
     t.index ["user_id"], name: "index_interviews_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180408123033) do
+ActiveRecord::Schema.define(version: 20180420110004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "interviews", force: :cascade do |t|
     t.datetime "scheduled_at"
-    t.boolean "is_available"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"


### PR DESCRIPTION
## やりたかったこと

- 面接日程一覧表示機能の追加
- 面接日程登録機能の追加
- 面接日程編集機能の追加
- 面接日程削除機能の追加

## やったこと

- Interviewモデルの追加
- Interviewsコントローラの追加
- UserモデルとInterviewモデルの関連付け
- 面接日程一覧表示機能の実装 Interviews#index
- 面接日程登録機能の実装 Interviews#new, create
- ユーザー・面接間の１対多の紐付きを反映したルーティング
- アプリケーションのタイムゾーン設定
- Interviewsコントローラのアクションに対するフィルター設定
- ユーザーの性別への値の割り当て方を変更
- 面接日程編集機能の実装 Interviews#edit, update
- 面接日程削除機能の実装 Interviews#destroy
- 面接日程用フォームをパーシャルに分離して登録・編集ページで使い回し

## 動作確認方法

- [ ] （ユーザーを新規で作成する）
- [ ] ログインする
- [ ] [自分の面接一覧]リンクから面接一覧ページに遷移する
- [ ] 「面接日程がありません。」と表示される
- [ ] "面接日程作成"リンクから面接登録ページに遷移する
- [ ] 年月日および時刻を入力し、"作成"ボタンを押す
- [ ] 面接一覧ページに自動的に遷移し、登録した日程が表示される
- [ ] 日程右側の"編集"リンクから面接編集ページに遷移する
- [ ] 年月日および時刻の一部または全部を変更し"更新"ボタンを押す
- [ ] 面接一覧ページに自動的に遷移し、日程が更新される
- [ ] 日程右側の"削除"リンクを押す
- [ ] 面接一覧ページに戻り、日程が削除される

※以下は性別に関する変更分

- [ ] [プロフィール]リンクからプロフィール編集ページに遷移する
  - [ ] 以前のバージョンで「男性」だった場合空欄、「女性」だった場合男性、「不明」だった場合女性になっている

## その他

性別の扱いについて変更したのは、以下記事に影響を受けたためです。
[システムで「性別」の情報を扱う前に知っておくべきこと - Qiita](https://qiita.com/aoshirobo/items/32deb45cb8c8b87d65a4#%E7%B5%90%E8%AB%96)
